### PR TITLE
iesy-osm-rpx30.xml: switch to static commit IDs

### DIFF
--- a/iesy-osm-rpx30.xml
+++ b/iesy-osm-rpx30.xml
@@ -10,16 +10,16 @@
   <remote fetch="https://github.com/meta-rust" name="rust"/>
   <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
   
-  <project name="meta-browser" remote="browser" revision="master" path="sources/meta-browser"/>
-  <project name="meta-clang" remote="clang" revision="kirkstone" path="sources/meta-clang"/>
-  <project name="meta-iesy-osm" remote="iesy" revision="kirkstone" path="sources/meta-iesy-osm"/>
-  <project name="meta-rockchip" remote="JeffyCN" revision="kirkstone" path="sources/meta-rockchip"/>
-  <project name="meta-openembedded" remote="oe" revision="kirkstone" path="sources/meta-openembedded"/>
-  <project name="meta-python2" remote="python2" revision="kirkstone" path="sources/meta-python2"/>
-  <project name="meta-qt5" remote="qt5" revision="kirkstone" path="sources/meta-qt5"/>
-  <project name="meta-rust" remote="rust" revision="master" path="sources/meta-rust"/>
+  <project name="meta-browser" remote="browser" revision="b279a4dc078ba6957815e2496820f1eadbafd58a" path="sources/meta-browser"/>
+  <project name="meta-clang" remote="clang" revision="7e3f2a4126d1bfacda497dfa6b59f3f471f1a984" path="sources/meta-clang"/>
+  <project name="meta-iesy-osm" remote="iesy" revision="f1f843ad27b2985324c648c454447e4a8e22498f" path="sources/meta-iesy-osm"/>
+  <project name="meta-rockchip" remote="JeffyCN" revision="2b86e86eb4ce6a46fbdbfc7c70273c121df0bad9" path="sources/meta-rockchip"/>
+  <project name="meta-openembedded" remote="oe" revision="571e36e20e9d1f27af0eb4545291beeb64f280e2" path="sources/meta-openembedded"/>
+  <project name="meta-python2" remote="python2" revision="f02882e2aa9279ca7becca8d0cedbffe88b5a253" path="sources/meta-python2"/>
+  <project name="meta-qt5" remote="qt5" revision="44d44933200287f7d17cf6981af4b4a0961c308d" path="sources/meta-qt5"/>
+  <project name="meta-rust" remote="rust" revision="816a860f2b7a40722a87aafc6b74e7a7bc4ad3eb" path="sources/meta-rust"/>
   
-  <project name="poky" remote="yocto" revision="kirkstone" path="sources/poky">
+  <project name="poky" remote="yocto" revision="09def309f91929f47c6cce386016ccb777bd2cfc" path="sources/poky">
 	  <linkfile dest="scripts" src="scripts"/>
 	  <linkfile dest="bitbake" src="bitbake"/>
 	  <linkfile dest="meta-poky" src="meta-poky"/>


### PR DESCRIPTION
To prevent build errors following changes in the layers, freeze the repo on known stable commit ids